### PR TITLE
Perbaiki error enoent saat deploy

### DIFF
--- a/RAILWAY_MONOREPO_FIX.md
+++ b/RAILWAY_MONOREPO_FIX.md
@@ -1,0 +1,68 @@
+# Railway Monorepo Deployment Fix
+
+## Problem
+Railway is looking for `package.json` in the root directory (`/app/package.json`), but your project has a monorepo structure with separate `package.json` files in `frontend/` and `backend/` directories.
+
+## Solution 1: Root package.json (Already Implemented)
+
+I've created a root `package.json` that treats your project as a monorepo with npm workspaces. This allows Railway to:
+1. Find the package.json in the root directory
+2. Install dependencies for both frontend and backend
+3. Build and run your application properly
+
+The root `package.json` includes:
+- Workspace configuration pointing to frontend and backend
+- Scripts to build and start both services
+- Node/npm version requirements
+
+## Solution 2: Separate Services (Recommended for Production)
+
+For better scalability and separation of concerns, deploy frontend and backend as separate services on Railway:
+
+### Frontend Service Setup:
+1. In Railway dashboard, create a new service
+2. Connect your GitHub repo
+3. Go to Settings → General
+4. Set **Root Directory** to `/frontend`
+5. Deploy
+
+### Backend Service Setup:
+1. Create another new service
+2. Connect the same GitHub repo
+3. Go to Settings → General
+4. Set **Root Directory** to `/backend`
+5. Deploy
+
+## Solution 3: Using nixpacks.toml
+
+Create a `nixpacks.toml` in your root directory:
+
+```toml
+[phases.setup]
+cmds = ["cd frontend && npm install"]
+
+[phases.build]
+cmds = ["cd frontend && npm run build"]
+
+[start]
+cmd = "cd frontend && npm run serve"
+```
+
+## Environment Variables
+
+Make sure to set these in Railway:
+- `PORT` - Railway provides this automatically
+- Any API URLs or environment-specific variables
+
+## Verification Steps
+
+1. Check Railway build logs for successful npm install
+2. Verify the build command completes without errors
+3. Ensure the start command finds the built files
+4. Check that the service is accessible via the Railway-provided URL
+
+## Common Issues
+
+1. **Port Binding**: Make sure your app uses `process.env.PORT || 3000`
+2. **Build Path**: Ensure serve command points to correct build directory
+3. **Dependencies**: All production dependencies should be in `dependencies`, not `devDependencies`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "expense-tracker-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "frontend",
+    "backend"
+  ],
+  "scripts": {
+    "install:all": "npm install",
+    "build:frontend": "cd frontend && npm run build",
+    "build:backend": "cd backend && npm ci",
+    "build": "npm run build:frontend",
+    "start:frontend": "cd frontend && serve -s build -l ${PORT:-3000}",
+    "start:backend": "cd backend && node server.js",
+    "start": "npm run start:frontend"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -2,10 +2,10 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm run build"
+    "buildCommand": "npm install && npm run build:frontend"
   },
   "deploy": {
-    "startCommand": "npx serve -s build -l $PORT",
+    "startCommand": "npm run start:frontend",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
Configure monorepo support for Railway deployment to resolve `package.json` not found error.

The original Railway deployment failed because it expected a `package.json` in the root directory, but the project has a monorepo structure with `package.json` files in `frontend` and `backend` subdirectories. This PR introduces a root `package.json` to define npm workspaces and updates `railway.json` to use monorepo-aware build and start commands, allowing Railway to correctly deploy the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2923b9e-9938-4f9c-8710-af9496509880">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2923b9e-9938-4f9c-8710-af9496509880">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>